### PR TITLE
Polish sync failure UX and structured telemetry

### DIFF
--- a/lib/presentation/providers/app_services_provider.dart
+++ b/lib/presentation/providers/app_services_provider.dart
@@ -65,23 +65,32 @@ class _SyncRequest {
 }
 
 class AppServicesProvider extends ChangeNotifier {
-  static const Duration _baseRetryDelay = Duration(seconds: 2);
-  static const Duration _maxRetryDelay = Duration(minutes: 5);
-  static const int _maxRetryAttempts = 8;
+  static const Duration _defaultBaseRetryDelay = Duration(seconds: 2);
+  static const Duration _defaultMaxRetryDelay = Duration(minutes: 5);
+  static const int _defaultMaxRetryAttempts = 8;
 
   final CloudSyncService _cloudSyncService;
   final DailyReminderService _dailyReminderService;
   final SyncConnectivity _syncConnectivity;
   final SyncTelemetry? _syncTelemetry;
+  final Duration _baseRetryDelay;
+  final Duration _maxRetryDelay;
+  final int _maxRetryAttempts;
 
   AppServicesProvider(
     this._cloudSyncService,
     this._dailyReminderService, {
     SyncConnectivity? syncConnectivity,
     SyncTelemetry? syncTelemetry,
+    Duration baseRetryDelay = _defaultBaseRetryDelay,
+    Duration maxRetryDelay = _defaultMaxRetryDelay,
+    int maxRetryAttempts = _defaultMaxRetryAttempts,
   }) : _syncConnectivity =
-           syncConnectivity ?? DeviceSyncConnectivity(Connectivity()),
-       _syncTelemetry = syncTelemetry {
+            syncConnectivity ?? DeviceSyncConnectivity(Connectivity()),
+       _syncTelemetry = syncTelemetry,
+       _baseRetryDelay = baseRetryDelay,
+       _maxRetryDelay = maxRetryDelay,
+       _maxRetryAttempts = maxRetryAttempts {
     _loadFromServices();
     _connectivityReady = _bootstrapConnectivity();
   }
@@ -214,6 +223,7 @@ class AppServicesProvider extends ChangeNotifier {
       notifyListeners();
 
       try {
+        final attemptNumber = _retryCount + 1;
         _lastSyncedAt = await _cloudSyncService.syncSnapshot(request.snapshot);
         _lastSyncSuccessAt = _lastSyncedAt;
         _lastSyncErrorCode = null;
@@ -227,11 +237,13 @@ class AppServicesProvider extends ChangeNotifier {
             ? 'Synced to Firebase successfully'
             : 'Firebase not configured. Saved local backup instead.';
         _syncSuccessCount += 1;
-        _recordTelemetry('sync_success', {
-          'reason': request.reason,
-          'retryCount': _retryCount,
-          'backend': cloudBackendLabel,
-        });
+        _recordTelemetry(
+          'sync_success',
+          _baseTelemetryMetadata(
+            reason: request.reason,
+            attemptNumber: attemptNumber,
+          ),
+        );
         notifyListeners();
 
         if (request.onSynced != null) {
@@ -244,12 +256,17 @@ class AppServicesProvider extends ChangeNotifier {
         _lastSyncErrorMessage = error.toString();
         _lastSyncErrorCategory = category;
         _syncFailureCount += 1;
-        _recordTelemetry('sync_failure', {
-          'reason': request.reason,
-          'retryable': retryable,
-          'category': category.name,
-          'code': _lastSyncErrorCode,
-        });
+        _recordTelemetry(
+          'sync_failure',
+          _baseTelemetryMetadata(
+            reason: request.reason,
+            retryable: retryable,
+            category: category,
+            code: _lastSyncErrorCode,
+            error: _lastSyncErrorMessage,
+            attemptNumber: _retryCount + 1,
+          ),
+        );
 
         if (!retryable) {
           _retryCount = 0;
@@ -268,6 +285,17 @@ class AppServicesProvider extends ChangeNotifier {
           _syncStatus = SyncStatus.failed;
           _syncMessage = 'Sync failed after retries. Please sync manually.';
           _nextRetryAt = null;
+          _recordTelemetry(
+            'sync_retry_exhausted',
+            _baseTelemetryMetadata(
+              reason: request.reason,
+              retryable: retryable,
+              category: category,
+              code: _lastSyncErrorCode,
+              error: _lastSyncErrorMessage,
+              attemptNumber: _retryCount,
+            ),
+          );
           notifyListeners();
           _isSyncing = false;
           return;
@@ -280,13 +308,17 @@ class AppServicesProvider extends ChangeNotifier {
             ? 'Offline. Sync will retry when online.'
             : 'Sync retry scheduled in ${delay.inSeconds}s.';
         _syncRetryScheduledCount += 1;
-        _recordTelemetry('sync_retry_scheduled', {
-          'reason': request.reason,
-          'retryCount': _retryCount,
-          'nextRetryInSeconds': delay.inSeconds,
-          'category': category.name,
-          'code': _lastSyncErrorCode,
-        });
+        _recordTelemetry(
+          'sync_retry_scheduled',
+          _baseTelemetryMetadata(
+            reason: request.reason,
+            category: category,
+            code: _lastSyncErrorCode,
+            error: _lastSyncErrorMessage,
+            nextRetryInSeconds: delay.inSeconds,
+            attemptNumber: _retryCount,
+          ),
+        );
         notifyListeners();
 
         _scheduleRetry(delay);
@@ -416,6 +448,32 @@ class AppServicesProvider extends ChangeNotifier {
 
   void _recordTelemetry(String event, Map<String, Object?> metadata) {
     _syncTelemetry?.record(event, metadata);
+  }
+
+  Map<String, Object?> _baseTelemetryMetadata({
+    required String reason,
+    int? attemptNumber,
+    bool? retryable,
+    SyncErrorCategory? category,
+    String? code,
+    String? error,
+    int? nextRetryInSeconds,
+  }) {
+    final metadata = <String, Object?>{
+      'reason': reason,
+      'backend': cloudBackendLabel,
+      'status': _syncStatus.name,
+      'retryCount': _retryCount,
+      'isOffline': _isOffline,
+      'attemptNumber': attemptNumber,
+      'category': category?.name,
+      'code': code,
+      'retryable': retryable,
+      'nextRetryInSeconds': nextRetryInSeconds,
+      'error': error,
+    };
+    metadata.removeWhere((_, value) => value == null);
+    return metadata;
   }
 
   Future<void> _bootstrapConnectivity() async {

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -1009,11 +1009,11 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     if (category == SyncErrorCategory.none) {
       return 'Last sync failed.';
     }
-    final categoryLabel = category.name;
+    final categoryLabel = _syncCategoryLabel(category);
     if (code == null || code.isEmpty || code == 'unknown') {
       return 'Reason: $categoryLabel issue';
     }
-    return 'Reason: $categoryLabel ($code)';
+    return 'Reason: $categoryLabel issue ($code)';
   }
 
   Future<void> _showSyncDetailsDialog(
@@ -1021,6 +1021,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     AppServicesProvider servicesProvider,
   ) async {
     final attempted = servicesProvider.lastSyncAttemptAt;
+    final lastSuccess = servicesProvider.lastSyncSuccessAt;
     final nextRetryAt = servicesProvider.nextRetryAt;
     final errorMessage = servicesProvider.lastSyncErrorMessage ?? 'N/A';
 
@@ -1034,11 +1035,16 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text('Status: ${servicesProvider.syncStatus.name}'),
-              Text('Category: ${servicesProvider.lastSyncErrorCategory.name}'),
+              Text(
+                'Category: ${_syncCategoryLabel(servicesProvider.lastSyncErrorCategory)}',
+              ),
               Text('Code: ${servicesProvider.lastSyncErrorCode ?? 'unknown'}'),
               Text('Retry attempts: ${servicesProvider.retryCount}'),
               Text(
                 'Last attempt: ${attempted == null ? 'N/A' : DateFormat('MMM d, HH:mm:ss').format(attempted)}',
+              ),
+              Text(
+                'Last success: ${lastSuccess == null ? 'N/A' : DateFormat('MMM d, HH:mm:ss').format(lastSuccess)}',
               ),
               Text(
                 'Next retry: ${nextRetryAt == null ? 'N/A' : DateFormat('MMM d, HH:mm:ss').format(nextRetryAt)}',
@@ -1070,6 +1076,25 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
         return Colors.orange[800]!;
       case SyncStatus.failed:
         return Colors.red[700]!;
+    }
+  }
+
+  String _syncCategoryLabel(SyncErrorCategory category) {
+    switch (category) {
+      case SyncErrorCategory.none:
+        return 'Unknown';
+      case SyncErrorCategory.network:
+        return 'Network';
+      case SyncErrorCategory.auth:
+        return 'Authentication';
+      case SyncErrorCategory.permission:
+        return 'Permission';
+      case SyncErrorCategory.validation:
+        return 'Validation';
+      case SyncErrorCategory.server:
+        return 'Server';
+      case SyncErrorCategory.unknown:
+        return 'Unknown';
     }
   }
 

--- a/test/app_services_provider_test.dart
+++ b/test/app_services_provider_test.dart
@@ -266,6 +266,73 @@ void main() {
       expect(eventNames, contains('sync_retry_scheduled'));
       expect(eventNames, contains('sync_success'));
 
+      final failureEvent = telemetry.events.firstWhere(
+        (entry) => entry['event'] == 'sync_failure',
+      );
+      expect(failureEvent['backend'], 'Firebase');
+      expect(failureEvent['reason'], 'launch');
+      expect(failureEvent['isOffline'], isFalse);
+      expect(failureEvent['category'], 'network');
+
+      final retryEvent = telemetry.events.firstWhere(
+        (entry) => entry['event'] == 'sync_retry_scheduled',
+      );
+      expect(retryEvent['nextRetryInSeconds'], 2);
+
+      final successEvent = telemetry.events.firstWhere(
+        (entry) => entry['event'] == 'sync_success',
+      );
+      expect(successEvent['attemptNumber'], 2);
+
+      provider.dispose();
+      await connectivity.dispose();
+    });
+
+    test('telemetry records retry exhaustion after max attempts', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final localDataSource = LocalDataSource(prefs);
+      final fakeSyncService = _FakeCloudSyncService();
+      final connectivity = _FakeConnectivity(false);
+      final telemetry = _FakeSyncTelemetry();
+
+      for (var i = 0; i < 3; i++) {
+        fakeSyncService.enqueueError(
+          FirebaseException(plugin: 'cloud_functions', code: 'unavailable'),
+        );
+      }
+
+      final provider = AppServicesProvider(
+        fakeSyncService,
+        LocalReminderService(localDataSource),
+        syncConnectivity: connectivity,
+        syncTelemetry: telemetry,
+        baseRetryDelay: const Duration(milliseconds: 10),
+        maxRetryDelay: const Duration(milliseconds: 20),
+        maxRetryAttempts: 2,
+      );
+
+      await provider.syncNow(
+        user: UserModel(totalXp: 12),
+        bookmarks: const [],
+        reason: 'launch',
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(provider.syncStatus, SyncStatus.failed);
+      expect(
+        provider.syncMessage,
+        'Sync failed after retries. Please sync manually.',
+      );
+
+      final exhaustedEvent = telemetry.events.firstWhere(
+        (entry) => entry['event'] == 'sync_retry_exhausted',
+      );
+      expect(exhaustedEvent['reason'], 'launch');
+      expect(exhaustedEvent['backend'], 'Firebase');
+      expect(exhaustedEvent['category'], 'network');
+      expect(exhaustedEvent['isOffline'], isFalse);
+
       provider.dispose();
       await connectivity.dispose();
     });

--- a/test/home_sync_status_test.dart
+++ b/test/home_sync_status_test.dart
@@ -124,6 +124,7 @@ void main() {
     expect(find.text('Status: Failed'), findsOneWidget);
     expect(find.text('Retry now'), findsOneWidget);
     expect(find.text('View details'), findsOneWidget);
+    expect(find.text('Sync details'), findsNothing);
 
     await tester.ensureVisible(find.text('View details'));
     await tester.tap(find.text('View details'));
@@ -131,7 +132,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 300));
 
     expect(find.text('Sync details'), findsOneWidget);
-    expect(find.textContaining('permission'), findsWidgets);
+    expect(find.textContaining('Permission'), findsOneWidget);
 
   });
 }

--- a/test/home_sync_status_test.dart
+++ b/test/home_sync_status_test.dart
@@ -132,7 +132,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 300));
 
     expect(find.text('Sync details'), findsOneWidget);
-    expect(find.textContaining('Permission'), findsOneWidget);
+    expect(find.text('Category: Permission'), findsOneWidget);
 
   });
 }


### PR DESCRIPTION
## Summary
- standardize sync telemetry payloads across success, failure, and retry events with consistent metadata (reason, status, attempt count, offline state, backend)
- add `sync_retry_exhausted` instrumentation and test-oriented retry configuration knobs in `AppServicesProvider`
- improve failed-sync messaging in Home and keep diagnostics behind the existing `View details` action with clearer category labels and timestamps
- expand provider/widget tests to verify telemetry metadata and failure-details UX behavior

## Notes
- could not run Flutter tests in this environment because the `flutter` binary is unavailable (`flutter not found`)