### PR TITLE
Surface lifetime sync telemetry counters in Home

### DIFF
--- a/lib/presentation/providers/app_services_provider.dart
+++ b/lib/presentation/providers/app_services_provider.dart
@@ -11,6 +11,8 @@ import '../../services/notifications/daily_reminder_service.dart';
 
 enum SyncStatus { idle, pending, syncing, retrying, failed }
 
+enum SyncOutcome { success, failure }
+
 enum SyncErrorCategory {
   none,
   network,
@@ -107,6 +109,8 @@ class AppServicesProvider extends ChangeNotifier {
   DateTime? _nextRetryAt;
   DateTime? _lastSyncAttemptAt;
   DateTime? _lastSyncSuccessAt;
+  DateTime? _lastSyncOutcomeAt;
+  SyncOutcome? _lastSyncOutcome;
   String? _lastSyncErrorCode;
   String? _lastSyncErrorMessage;
   SyncErrorCategory _lastSyncErrorCategory = SyncErrorCategory.none;
@@ -135,6 +139,8 @@ class AppServicesProvider extends ChangeNotifier {
   DateTime? get nextRetryAt => _nextRetryAt;
   DateTime? get lastSyncAttemptAt => _lastSyncAttemptAt;
   DateTime? get lastSyncSuccessAt => _lastSyncSuccessAt;
+  DateTime? get lastSyncOutcomeAt => _lastSyncOutcomeAt;
+  SyncOutcome? get lastSyncOutcome => _lastSyncOutcome;
   String? get lastSyncErrorCode => _lastSyncErrorCode;
   String? get lastSyncErrorMessage => _lastSyncErrorMessage;
   SyncErrorCategory get lastSyncErrorCategory => _lastSyncErrorCategory;
@@ -229,6 +235,8 @@ class AppServicesProvider extends ChangeNotifier {
         _lastSyncErrorCode = null;
         _lastSyncErrorMessage = null;
         _lastSyncErrorCategory = SyncErrorCategory.none;
+        _lastSyncOutcome = SyncOutcome.success;
+        _lastSyncOutcomeAt = _lastSyncedAt;
         _retryCount = 0;
         _nextRetryAt = null;
         _cancelRetry();
@@ -273,6 +281,8 @@ class AppServicesProvider extends ChangeNotifier {
           _nextRetryAt = null;
           _syncStatus = SyncStatus.failed;
           _syncMessage = _failureMessageForCategory(category);
+          _lastSyncOutcome = SyncOutcome.failure;
+          _lastSyncOutcomeAt = DateTime.now();
           notifyListeners();
           _isSyncing = false;
           return;
@@ -285,6 +295,8 @@ class AppServicesProvider extends ChangeNotifier {
           _syncStatus = SyncStatus.failed;
           _syncMessage = 'Sync failed after retries. Please sync manually.';
           _nextRetryAt = null;
+          _lastSyncOutcome = SyncOutcome.failure;
+          _lastSyncOutcomeAt = DateTime.now();
           _recordTelemetry(
             'sync_retry_exhausted',
             _baseTelemetryMetadata(
@@ -559,6 +571,8 @@ class AppServicesProvider extends ChangeNotifier {
   void _loadFromServices() {
     _lastSyncedAt = _cloudSyncService.getLastSyncedAt();
     _lastSyncSuccessAt = _lastSyncedAt;
+    _lastSyncOutcomeAt = _lastSyncedAt;
+    _lastSyncOutcome = _lastSyncedAt == null ? null : SyncOutcome.success;
     _reminderEnabled = _dailyReminderService.isEnabled;
     _reminderTime = _dailyReminderService.reminderTime;
   }

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -504,6 +504,16 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                     fontWeight: FontWeight.w600,
                   ),
                 ),
+                const SizedBox(height: 8),
+                Text(
+                  'Successes: ${servicesProvider.syncSuccessCount} • Failures: ${servicesProvider.syncFailureCount} • Retries scheduled: ${servicesProvider.syncRetryScheduledCount}',
+                  style: TextStyle(color: Colors.grey[700], fontSize: 13),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  'Last outcome: ${_syncOutcomeLabel(servicesProvider)}',
+                  style: TextStyle(color: Colors.grey[700], fontSize: 13),
+                ),
                 const SizedBox(height: 12),
                 SizedBox(
                   width: double.infinity,
@@ -1039,6 +1049,12 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                 'Category: ${_syncCategoryLabel(servicesProvider.lastSyncErrorCategory)}',
               ),
               Text('Code: ${servicesProvider.lastSyncErrorCode ?? 'unknown'}'),
+              Text('Successes: ${servicesProvider.syncSuccessCount}'),
+              Text('Failures: ${servicesProvider.syncFailureCount}'),
+              Text(
+                'Retries scheduled: ${servicesProvider.syncRetryScheduledCount}',
+              ),
+              Text('Last outcome: ${_syncOutcomeLabel(servicesProvider)}'),
               Text('Retry attempts: ${servicesProvider.retryCount}'),
               Text(
                 'Last attempt: ${attempted == null ? 'N/A' : DateFormat('MMM d, HH:mm:ss').format(attempted)}',
@@ -1096,6 +1112,17 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       case SyncErrorCategory.unknown:
         return 'Unknown';
     }
+  }
+
+  String _syncOutcomeLabel(AppServicesProvider servicesProvider) {
+    final outcome = servicesProvider.lastSyncOutcome;
+    final at = servicesProvider.lastSyncOutcomeAt;
+    if (outcome == null || at == null) {
+      return 'N/A';
+    }
+    final outcomeLabel =
+        outcome == SyncOutcome.success ? 'Success' : 'Failure';
+    return '$outcomeLabel at ${DateFormat('MMM d, HH:mm:ss').format(at)}';
   }
 
   Widget _buildXpGainBanner(String message) {

--- a/test/app_services_provider_test.dart
+++ b/test/app_services_provider_test.dart
@@ -117,6 +117,8 @@ void main() {
       expect(provider.lastSyncedAt, isNotNull);
       expect(fakeSyncService.lastSnapshot, isNotNull);
       expect(provider.syncStatus, SyncStatus.idle);
+      expect(provider.lastSyncOutcome, SyncOutcome.success);
+      expect(provider.lastSyncOutcomeAt, isNotNull);
 
       provider.dispose();
       await connectivity.dispose();
@@ -193,6 +195,8 @@ void main() {
         expect(provider.retryCount, 0);
         expect(provider.nextRetryAt, isNull);
         expect(provider.lastSyncErrorCategory, SyncErrorCategory.validation);
+        expect(provider.lastSyncOutcome, SyncOutcome.failure);
+        expect(provider.lastSyncOutcomeAt, isNotNull);
 
         provider.dispose();
         await connectivity.dispose();
@@ -228,6 +232,8 @@ void main() {
       expect(provider.syncStatus, SyncStatus.idle);
       expect(provider.lastSyncErrorCategory, SyncErrorCategory.none);
       expect(provider.syncSuccessCount, 1);
+      expect(provider.lastSyncOutcome, SyncOutcome.success);
+      expect(provider.lastSyncOutcomeAt, isNotNull);
 
       provider.dispose();
       await connectivity.dispose();
@@ -324,6 +330,8 @@ void main() {
         provider.syncMessage,
         'Sync failed after retries. Please sync manually.',
       );
+      expect(provider.lastSyncOutcome, SyncOutcome.failure);
+      expect(provider.lastSyncOutcomeAt, isNotNull);
 
       final exhaustedEvent = telemetry.events.firstWhere(
         (entry) => entry['event'] == 'sync_retry_exhausted',

--- a/test/home_sync_status_test.dart
+++ b/test/home_sync_status_test.dart
@@ -122,6 +122,11 @@ void main() {
     await tester.pump(const Duration(milliseconds: 300));
 
     expect(find.text('Status: Failed'), findsOneWidget);
+    expect(
+      find.text('Successes: 0 • Failures: 1 • Retries scheduled: 0'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('Last outcome: Failure at'), findsOneWidget);
     expect(find.text('Retry now'), findsOneWidget);
     expect(find.text('View details'), findsOneWidget);
     expect(find.text('Sync details'), findsNothing);
@@ -132,6 +137,9 @@ void main() {
     await tester.pump(const Duration(milliseconds: 300));
 
     expect(find.text('Sync details'), findsOneWidget);
+    expect(find.text('Successes: 0'), findsOneWidget);
+    expect(find.text('Failures: 1'), findsOneWidget);
+    expect(find.text('Retries scheduled: 0'), findsOneWidget);
     expect(find.text('Category: Permission'), findsOneWidget);
 
   });


### PR DESCRIPTION
## Summary
- add explicit sync outcome state (`success`/`failure`) and timestamp tracking in `AppServicesProvider`
- surface lifetime sync counters and last outcome in the Home `Backup & Reminders` card
- extend `View details` diagnostics with success/failure/retry counts and last outcome context
- update provider and widget tests to verify outcome tracking and counter rendering while keeping details behind the `View details` action

## Notes
- local Flutter test execution was not possible in this environment because `flutter` is unavailable (`flutter not found`)