### PR TITLE
Add sync health indicators and copyable diagnostics

### DIFF
--- a/lib/data/datasources/local_data_source.dart
+++ b/lib/data/datasources/local_data_source.dart
@@ -14,6 +14,11 @@ class LocalDataSource {
   static const String _cloudLastSyncedAtKey = 'cloud_last_synced_at';
   static const String _dailyReminderEnabledKey = 'daily_reminder_enabled';
   static const String _dailyReminderTimeKey = 'daily_reminder_time';
+  static const String _syncSuccessCountKey = 'sync_success_count';
+  static const String _syncFailureCountKey = 'sync_failure_count';
+  static const String _syncRetryScheduledCountKey = 'sync_retry_scheduled_count';
+  static const String _syncLastOutcomeKey = 'sync_last_outcome';
+  static const String _syncLastOutcomeAtKey = 'sync_last_outcome_at';
   final SharedPreferences _prefs;
 
   LocalDataSource(this._prefs);
@@ -169,5 +174,57 @@ class LocalDataSource {
 
   Future<void> saveDailyReminderTime(String value) async {
     await _prefs.setString(_dailyReminderTimeKey, value);
+  }
+
+  int getSyncSuccessCount() {
+    return _prefs.getInt(_syncSuccessCountKey) ?? 0;
+  }
+
+  Future<void> saveSyncSuccessCount(int value) async {
+    await _prefs.setInt(_syncSuccessCountKey, value);
+  }
+
+  int getSyncFailureCount() {
+    return _prefs.getInt(_syncFailureCountKey) ?? 0;
+  }
+
+  Future<void> saveSyncFailureCount(int value) async {
+    await _prefs.setInt(_syncFailureCountKey, value);
+  }
+
+  int getSyncRetryScheduledCount() {
+    return _prefs.getInt(_syncRetryScheduledCountKey) ?? 0;
+  }
+
+  Future<void> saveSyncRetryScheduledCount(int value) async {
+    await _prefs.setInt(_syncRetryScheduledCountKey, value);
+  }
+
+  String? getSyncLastOutcome() {
+    return _prefs.getString(_syncLastOutcomeKey);
+  }
+
+  Future<void> saveSyncLastOutcome(String? value) async {
+    if (value == null || value.isEmpty) {
+      await _prefs.remove(_syncLastOutcomeKey);
+      return;
+    }
+    await _prefs.setString(_syncLastOutcomeKey, value);
+  }
+
+  DateTime? getSyncLastOutcomeAt() {
+    final iso = _prefs.getString(_syncLastOutcomeAtKey);
+    if (iso == null || iso.isEmpty) {
+      return null;
+    }
+    return DateTime.tryParse(iso);
+  }
+
+  Future<void> saveSyncLastOutcomeAt(DateTime? value) async {
+    if (value == null) {
+      await _prefs.remove(_syncLastOutcomeAtKey);
+      return;
+    }
+    await _prefs.setString(_syncLastOutcomeAtKey, value.toIso8601String());
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,7 +54,11 @@ void main() async {
         ),
         ChangeNotifierProvider(
           create: (_) =>
-              AppServicesProvider(cloudSyncService, dailyReminderService),
+              AppServicesProvider(
+                cloudSyncService,
+                dailyReminderService,
+                localDataSource: localDataSource,
+              ),
         ),
       ],
       child: const DailyBreadApp(),

--- a/lib/presentation/providers/app_services_provider.dart
+++ b/lib/presentation/providers/app_services_provider.dart
@@ -648,9 +648,7 @@ class AppServicesProvider extends ChangeNotifier {
     await localDataSource.saveSyncSuccessCount(_syncSuccessCount);
     await localDataSource.saveSyncFailureCount(_syncFailureCount);
     await localDataSource.saveSyncRetryScheduledCount(_syncRetryScheduledCount);
-    await localDataSource.saveSyncLastOutcome(
-      _lastSyncOutcome == null ? null : _lastSyncOutcome!.name,
-    );
+    await localDataSource.saveSyncLastOutcome(_lastSyncOutcome?.name);
     await localDataSource.saveSyncLastOutcomeAt(_lastSyncOutcomeAt);
   }
 

--- a/lib/presentation/providers/app_services_provider.dart
+++ b/lib/presentation/providers/app_services_provider.dart
@@ -4,6 +4,7 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 
+import '../../data/datasources/local_data_source.dart';
 import '../../data/models/user_model.dart';
 import '../../data/models/verse_bookmark_model.dart';
 import '../../services/cloud/cloud_sync_service.dart';
@@ -12,6 +13,8 @@ import '../../services/notifications/daily_reminder_service.dart';
 enum SyncStatus { idle, pending, syncing, retrying, failed }
 
 enum SyncOutcome { success, failure }
+
+enum SyncHealth { unknown, healthy, degraded, critical }
 
 enum SyncErrorCategory {
   none,
@@ -75,6 +78,7 @@ class AppServicesProvider extends ChangeNotifier {
   final DailyReminderService _dailyReminderService;
   final SyncConnectivity _syncConnectivity;
   final SyncTelemetry? _syncTelemetry;
+  final LocalDataSource? _localDataSource;
   final Duration _baseRetryDelay;
   final Duration _maxRetryDelay;
   final int _maxRetryAttempts;
@@ -84,12 +88,14 @@ class AppServicesProvider extends ChangeNotifier {
     this._dailyReminderService, {
     SyncConnectivity? syncConnectivity,
     SyncTelemetry? syncTelemetry,
+    LocalDataSource? localDataSource,
     Duration baseRetryDelay = _defaultBaseRetryDelay,
     Duration maxRetryDelay = _defaultMaxRetryDelay,
     int maxRetryAttempts = _defaultMaxRetryAttempts,
   }) : _syncConnectivity =
             syncConnectivity ?? DeviceSyncConnectivity(Connectivity()),
        _syncTelemetry = syncTelemetry,
+       _localDataSource = localDataSource,
        _baseRetryDelay = baseRetryDelay,
        _maxRetryDelay = maxRetryDelay,
        _maxRetryAttempts = maxRetryAttempts {
@@ -148,6 +154,31 @@ class AppServicesProvider extends ChangeNotifier {
   int get syncSuccessCount => _syncSuccessCount;
   int get syncFailureCount => _syncFailureCount;
   int get syncRetryScheduledCount => _syncRetryScheduledCount;
+  SyncHealth get syncHealth {
+    if (_syncSuccessCount == 0 && _syncFailureCount == 0) {
+      return SyncHealth.unknown;
+    }
+    if (_syncFailureCount > 0 && _syncSuccessCount == 0) {
+      return SyncHealth.critical;
+    }
+    if (_syncFailureCount > _syncSuccessCount) {
+      return SyncHealth.degraded;
+    }
+    return SyncHealth.healthy;
+  }
+
+  String get syncHealthLabel {
+    switch (syncHealth) {
+      case SyncHealth.unknown:
+        return 'Unknown';
+      case SyncHealth.healthy:
+        return 'Healthy';
+      case SyncHealth.degraded:
+        return 'Needs attention';
+      case SyncHealth.critical:
+        return 'Critical';
+    }
+  }
 
   Future<void> syncNow({
     required UserModel user,
@@ -245,6 +276,7 @@ class AppServicesProvider extends ChangeNotifier {
             ? 'Synced to Firebase successfully'
             : 'Firebase not configured. Saved local backup instead.';
         _syncSuccessCount += 1;
+        await _persistSyncTelemetryState();
         _recordTelemetry(
           'sync_success',
           _baseTelemetryMetadata(
@@ -283,6 +315,7 @@ class AppServicesProvider extends ChangeNotifier {
           _syncMessage = _failureMessageForCategory(category);
           _lastSyncOutcome = SyncOutcome.failure;
           _lastSyncOutcomeAt = DateTime.now();
+          await _persistSyncTelemetryState();
           notifyListeners();
           _isSyncing = false;
           return;
@@ -297,6 +330,7 @@ class AppServicesProvider extends ChangeNotifier {
           _nextRetryAt = null;
           _lastSyncOutcome = SyncOutcome.failure;
           _lastSyncOutcomeAt = DateTime.now();
+          await _persistSyncTelemetryState();
           _recordTelemetry(
             'sync_retry_exhausted',
             _baseTelemetryMetadata(
@@ -320,6 +354,7 @@ class AppServicesProvider extends ChangeNotifier {
             ? 'Offline. Sync will retry when online.'
             : 'Sync retry scheduled in ${delay.inSeconds}s.';
         _syncRetryScheduledCount += 1;
+        await _persistSyncTelemetryState();
         _recordTelemetry(
           'sync_retry_scheduled',
           _baseTelemetryMetadata(
@@ -571,10 +606,52 @@ class AppServicesProvider extends ChangeNotifier {
   void _loadFromServices() {
     _lastSyncedAt = _cloudSyncService.getLastSyncedAt();
     _lastSyncSuccessAt = _lastSyncedAt;
-    _lastSyncOutcomeAt = _lastSyncedAt;
-    _lastSyncOutcome = _lastSyncedAt == null ? null : SyncOutcome.success;
+    _loadSyncTelemetryState();
+    if (_lastSyncOutcomeAt == null && _lastSyncedAt != null) {
+      _lastSyncOutcomeAt = _lastSyncedAt;
+      _lastSyncOutcome = SyncOutcome.success;
+    }
     _reminderEnabled = _dailyReminderService.isEnabled;
     _reminderTime = _dailyReminderService.reminderTime;
+  }
+
+  void _loadSyncTelemetryState() {
+    final localDataSource = _localDataSource;
+    if (localDataSource == null) {
+      return;
+    }
+
+    _syncSuccessCount = localDataSource.getSyncSuccessCount();
+    _syncFailureCount = localDataSource.getSyncFailureCount();
+    _syncRetryScheduledCount = localDataSource.getSyncRetryScheduledCount();
+    _lastSyncOutcomeAt = localDataSource.getSyncLastOutcomeAt();
+
+    switch (localDataSource.getSyncLastOutcome()) {
+      case 'success':
+        _lastSyncOutcome = SyncOutcome.success;
+        break;
+      case 'failure':
+        _lastSyncOutcome = SyncOutcome.failure;
+        break;
+      default:
+        _lastSyncOutcome = null;
+        break;
+    }
+  }
+
+  Future<void> _persistSyncTelemetryState() async {
+    final localDataSource = _localDataSource;
+    if (localDataSource == null) {
+      return;
+    }
+
+    await localDataSource.saveSyncSuccessCount(_syncSuccessCount);
+    await localDataSource.saveSyncFailureCount(_syncFailureCount);
+    await localDataSource.saveSyncRetryScheduledCount(_syncRetryScheduledCount);
+    await localDataSource.saveSyncLastOutcome(
+      _lastSyncOutcome == null ? null : _lastSyncOutcome!.name,
+    );
+    await localDataSource.saveSyncLastOutcomeAt(_lastSyncOutcomeAt);
   }
 
   @override

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:intl/intl.dart';
 import '../providers/user_provider.dart';
@@ -513,6 +514,15 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                 Text(
                   'Last outcome: ${_syncOutcomeLabel(servicesProvider)}',
                   style: TextStyle(color: Colors.grey[700], fontSize: 13),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  'Sync health: ${servicesProvider.syncHealthLabel}',
+                  style: TextStyle(
+                    color: _syncHealthColor(servicesProvider),
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
                 const SizedBox(height: 12),
                 SizedBox(
@@ -1027,7 +1037,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   }
 
   Future<void> _showSyncDetailsDialog(
-    BuildContext context,
+    BuildContext parentContext,
     AppServicesProvider servicesProvider,
   ) async {
     final attempted = servicesProvider.lastSyncAttemptAt;
@@ -1036,8 +1046,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     final errorMessage = servicesProvider.lastSyncErrorMessage ?? 'N/A';
 
     await showDialog<void>(
-      context: context,
-      builder: (context) {
+      context: parentContext,
+      builder: (dialogContext) {
         return AlertDialog(
           title: const Text('Sync details'),
           content: Column(
@@ -1045,6 +1055,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text('Status: ${servicesProvider.syncStatus.name}'),
+              Text('Health: ${servicesProvider.syncHealthLabel}'),
               Text(
                 'Category: ${_syncCategoryLabel(servicesProvider.lastSyncErrorCategory)}',
               ),
@@ -1071,13 +1082,55 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
           ),
           actions: [
             TextButton(
-              onPressed: () => Navigator.of(context).pop(),
+              onPressed: () async {
+                await Clipboard.setData(
+                  ClipboardData(text: _syncDiagnosticsText(servicesProvider)),
+                );
+                if (!parentContext.mounted) {
+                  return;
+                }
+                ScaffoldMessenger.of(parentContext).showSnackBar(
+                  const SnackBar(
+                    content: Text('Diagnostics copied'),
+                    duration: Duration(seconds: 2),
+                  ),
+                );
+              },
+              child: const Text('Copy diagnostics'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
               child: const Text('Close'),
             ),
           ],
         );
       },
     );
+  }
+
+  String _syncDiagnosticsText(AppServicesProvider servicesProvider) {
+    final attempted = servicesProvider.lastSyncAttemptAt;
+    final lastSuccess = servicesProvider.lastSyncSuccessAt;
+    final lastOutcomeAt = servicesProvider.lastSyncOutcomeAt;
+    final nextRetryAt = servicesProvider.nextRetryAt;
+
+    return [
+      'Backend: ${servicesProvider.cloudBackendLabel}',
+      'Status: ${servicesProvider.syncStatus.name}',
+      'Health: ${servicesProvider.syncHealthLabel}',
+      'Offline: ${servicesProvider.isOffline}',
+      'Category: ${_syncCategoryLabel(servicesProvider.lastSyncErrorCategory)}',
+      'Code: ${servicesProvider.lastSyncErrorCode ?? 'unknown'}',
+      'Retry attempts: ${servicesProvider.retryCount}',
+      'Successes: ${servicesProvider.syncSuccessCount}',
+      'Failures: ${servicesProvider.syncFailureCount}',
+      'Retries scheduled: ${servicesProvider.syncRetryScheduledCount}',
+      'Last attempt: ${attempted == null ? 'N/A' : DateFormat('MMM d, HH:mm:ss').format(attempted)}',
+      'Last success: ${lastSuccess == null ? 'N/A' : DateFormat('MMM d, HH:mm:ss').format(lastSuccess)}',
+      'Last outcome: ${servicesProvider.lastSyncOutcome == null || lastOutcomeAt == null ? 'N/A' : '${servicesProvider.lastSyncOutcome!.name} at ${DateFormat('MMM d, HH:mm:ss').format(lastOutcomeAt)}'}',
+      'Next retry: ${nextRetryAt == null ? 'N/A' : DateFormat('MMM d, HH:mm:ss').format(nextRetryAt)}',
+      'Error: ${servicesProvider.lastSyncErrorMessage ?? 'N/A'}',
+    ].join('\n');
   }
 
   Color _syncStatusColor(AppServicesProvider servicesProvider) {
@@ -1123,6 +1176,19 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     final outcomeLabel =
         outcome == SyncOutcome.success ? 'Success' : 'Failure';
     return '$outcomeLabel at ${DateFormat('MMM d, HH:mm:ss').format(at)}';
+  }
+
+  Color _syncHealthColor(AppServicesProvider servicesProvider) {
+    switch (servicesProvider.syncHealth) {
+      case SyncHealth.unknown:
+        return Colors.grey[700]!;
+      case SyncHealth.healthy:
+        return Colors.green[700]!;
+      case SyncHealth.degraded:
+        return Colors.orange[800]!;
+      case SyncHealth.critical:
+        return Colors.red[700]!;
+    }
   }
 
   Widget _buildXpGainBanner(String message) {

--- a/test/app_services_provider_test.dart
+++ b/test/app_services_provider_test.dart
@@ -99,6 +99,7 @@ void main() {
         fakeSyncService,
         LocalReminderService(localDataSource),
         syncConnectivity: connectivity,
+        localDataSource: localDataSource,
       );
 
       await provider.syncNow(
@@ -141,6 +142,7 @@ void main() {
           fakeSyncService,
           LocalReminderService(localDataSource),
           syncConnectivity: connectivity,
+          localDataSource: localDataSource,
         );
 
         await provider.syncNow(
@@ -184,6 +186,7 @@ void main() {
           fakeSyncService,
           LocalReminderService(localDataSource),
           syncConnectivity: connectivity,
+          localDataSource: localDataSource,
         );
 
         await provider.syncNow(
@@ -218,6 +221,7 @@ void main() {
         fakeSyncService,
         LocalReminderService(localDataSource),
         syncConnectivity: connectivity,
+        localDataSource: localDataSource,
       );
 
       await provider.syncNow(user: UserModel(totalXp: 8), bookmarks: const []);
@@ -256,6 +260,7 @@ void main() {
         LocalReminderService(localDataSource),
         syncConnectivity: connectivity,
         syncTelemetry: telemetry,
+        localDataSource: localDataSource,
       );
 
       await provider.syncNow(
@@ -313,6 +318,7 @@ void main() {
         LocalReminderService(localDataSource),
         syncConnectivity: connectivity,
         syncTelemetry: telemetry,
+        localDataSource: localDataSource,
         baseRetryDelay: const Duration(milliseconds: 10),
         maxRetryDelay: const Duration(milliseconds: 20),
         maxRetryAttempts: 2,
@@ -356,6 +362,7 @@ void main() {
         fakeSyncService,
         LocalReminderService(localDataSource),
         syncConnectivity: connectivity,
+        localDataSource: localDataSource,
       );
 
       await provider.requestSync(
@@ -387,6 +394,7 @@ void main() {
         _FakeCloudSyncService(),
         LocalReminderService(localDataSource),
         syncConnectivity: connectivity,
+        localDataSource: localDataSource,
       );
 
       await provider.setReminderEnabled(true);
@@ -396,6 +404,7 @@ void main() {
         _FakeCloudSyncService(),
         LocalReminderService(localDataSource),
         syncConnectivity: connectivity,
+        localDataSource: localDataSource,
       );
 
       expect(reloaded.reminderEnabled, isTrue);
@@ -404,6 +413,84 @@ void main() {
 
       provider.dispose();
       reloaded.dispose();
+      await connectivity.dispose();
+    });
+
+    test('sync telemetry counters and outcome persist across provider reloads', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final localDataSource = LocalDataSource(prefs);
+
+      final firstSyncService = _FakeCloudSyncService();
+      final firstConnectivity = _FakeConnectivity(false);
+      firstSyncService.enqueueError(
+        FirebaseException(plugin: 'cloud_functions', code: 'permission-denied'),
+      );
+
+      final first = AppServicesProvider(
+        firstSyncService,
+        LocalReminderService(localDataSource),
+        syncConnectivity: firstConnectivity,
+        localDataSource: localDataSource,
+      );
+
+      await first.syncNow(user: UserModel(totalXp: 10), bookmarks: const []);
+      expect(first.syncFailureCount, 1);
+      expect(first.lastSyncOutcome, SyncOutcome.failure);
+
+      first.dispose();
+      await firstConnectivity.dispose();
+
+      final secondConnectivity = _FakeConnectivity(false);
+      final second = AppServicesProvider(
+        _FakeCloudSyncService(),
+        LocalReminderService(localDataSource),
+        syncConnectivity: secondConnectivity,
+        localDataSource: localDataSource,
+      );
+
+      expect(second.syncFailureCount, 1);
+      expect(second.syncSuccessCount, 0);
+      expect(second.lastSyncOutcome, SyncOutcome.failure);
+      expect(second.lastSyncOutcomeAt, isNotNull);
+      expect(second.syncHealth, SyncHealth.critical);
+
+      second.dispose();
+      await secondConnectivity.dispose();
+    });
+
+    test('sync health reflects unknown, critical, degraded, and healthy states', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final localDataSource = LocalDataSource(prefs);
+      final fakeSyncService = _FakeCloudSyncService();
+      final connectivity = _FakeConnectivity(false);
+
+      final provider = AppServicesProvider(
+        fakeSyncService,
+        LocalReminderService(localDataSource),
+        syncConnectivity: connectivity,
+        localDataSource: localDataSource,
+      );
+
+      expect(provider.syncHealth, SyncHealth.unknown);
+
+      fakeSyncService.enqueueError(
+        FirebaseException(plugin: 'cloud_functions', code: 'invalid-argument'),
+      );
+      await provider.syncNow(user: UserModel(totalXp: 5), bookmarks: const []);
+      expect(provider.syncHealth, SyncHealth.critical);
+
+      await provider.syncNow(user: UserModel(totalXp: 6), bookmarks: const []);
+      expect(provider.syncHealth, SyncHealth.healthy);
+
+      fakeSyncService.enqueueError(
+        FirebaseException(plugin: 'cloud_functions', code: 'permission-denied'),
+      );
+      await provider.syncNow(user: UserModel(totalXp: 7), bookmarks: const []);
+      expect(provider.syncHealth, SyncHealth.degraded);
+
+      provider.dispose();
       await connectivity.dispose();
     });
   });

--- a/test/home_sync_status_test.dart
+++ b/test/home_sync_status_test.dart
@@ -14,6 +14,7 @@ import 'package:daily_bread/services/cloud/cloud_sync_service.dart';
 import 'package:daily_bread/services/notifications/daily_reminder_service.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -65,6 +66,16 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('shows failed sync status with retry controls', (tester) async {
+    String? clipboardText;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (methodCall) async {
+          if (methodCall.method == 'Clipboard.setData') {
+            clipboardText = (methodCall.arguments as Map)['text'] as String;
+            return null;
+          }
+          return null;
+        });
+
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
     final localDataSource = LocalDataSource(prefs);
@@ -127,6 +138,7 @@ void main() {
       findsOneWidget,
     );
     expect(find.textContaining('Last outcome: Failure at'), findsOneWidget);
+    expect(find.text('Sync health: Critical'), findsOneWidget);
     expect(find.text('Retry now'), findsOneWidget);
     expect(find.text('View details'), findsOneWidget);
     expect(find.text('Sync details'), findsNothing);
@@ -140,7 +152,19 @@ void main() {
     expect(find.text('Successes: 0'), findsOneWidget);
     expect(find.text('Failures: 1'), findsOneWidget);
     expect(find.text('Retries scheduled: 0'), findsOneWidget);
+    expect(find.text('Health: Critical'), findsOneWidget);
     expect(find.text('Category: Permission'), findsOneWidget);
+
+    await tester.tap(find.text('Copy diagnostics'));
+    await tester.pump();
+    expect(find.text('Diagnostics copied'), findsOneWidget);
+    expect(clipboardText, isNotNull);
+    expect(clipboardText, contains('Health: Critical'));
+    expect(clipboardText, contains('Failures: 1'));
+    expect(clipboardText, contains('Category: Permission'));
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
 
   });
 }

--- a/test/user_repository_test.dart
+++ b/test/user_repository_test.dart
@@ -185,6 +185,11 @@ class _InMemoryLocalDataSource implements LocalDataSource {
   DateTime? _cloudLastSyncedAt;
   bool _dailyReminderEnabled = false;
   String _dailyReminderTime = '08:00';
+  int _syncSuccessCount = 0;
+  int _syncFailureCount = 0;
+  int _syncRetryScheduledCount = 0;
+  String? _syncLastOutcome;
+  DateTime? _syncLastOutcomeAt;
 
   void seedUser(UserModel user) {
     _user = user;
@@ -313,5 +318,55 @@ class _InMemoryLocalDataSource implements LocalDataSource {
   @override
   Future<void> saveDailyReminderTime(String value) async {
     _dailyReminderTime = value;
+  }
+
+  @override
+  int getSyncSuccessCount() {
+    return _syncSuccessCount;
+  }
+
+  @override
+  Future<void> saveSyncSuccessCount(int value) async {
+    _syncSuccessCount = value;
+  }
+
+  @override
+  int getSyncFailureCount() {
+    return _syncFailureCount;
+  }
+
+  @override
+  Future<void> saveSyncFailureCount(int value) async {
+    _syncFailureCount = value;
+  }
+
+  @override
+  int getSyncRetryScheduledCount() {
+    return _syncRetryScheduledCount;
+  }
+
+  @override
+  Future<void> saveSyncRetryScheduledCount(int value) async {
+    _syncRetryScheduledCount = value;
+  }
+
+  @override
+  String? getSyncLastOutcome() {
+    return _syncLastOutcome;
+  }
+
+  @override
+  Future<void> saveSyncLastOutcome(String? value) async {
+    _syncLastOutcome = value;
+  }
+
+  @override
+  DateTime? getSyncLastOutcomeAt() {
+    return _syncLastOutcomeAt;
+  }
+
+  @override
+  Future<void> saveSyncLastOutcomeAt(DateTime? value) async {
+    _syncLastOutcomeAt = value;
   }
 }


### PR DESCRIPTION
## Summary
- persist lifetime sync counters and last outcome metadata in local storage
- derive a sync health state in `AppServicesProvider` and surface it in the Home backup card
- extend sync details with a `Copy diagnostics` action that exports structured status and telemetry context
- add provider tests for persistence and health classification, plus widget coverage for health UI and clipboard diagnostics copy

## Notes
- local Flutter test execution was not possible in this environment because `flutter` is unavailable (`flutter not found`)